### PR TITLE
Fix nonlinear runtime in stateCannotBeABaseUrl

### DIFF
--- a/url/url_test.go
+++ b/url/url_test.go
@@ -18,9 +18,11 @@ package url
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -604,6 +606,25 @@ func TestUrl_Getters(t *testing.T) {
 			}
 			if got := u.Fragment(); got != tt.fragment {
 				t.Errorf("Fragment() = %v, want %v", got, tt.fragment)
+			}
+		})
+	}
+}
+
+func BenchmarkIssue6(b *testing.B) {
+	// https://github.com/nlnwa/whatwg-url/issues/6
+	for i := 10; i <= 20; i++ {
+		n := 1 << i
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			var buf strings.Builder
+			buf.Grow(n + 32)
+			buf.WriteString("data:text/javascript,")
+			for j := 0; j <= n; j++ {
+				buf.WriteString("A")
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = Parse(buf.String())
 			}
 		})
 	}


### PR DESCRIPTION
This problem can be triggered by feeding long data URLs into the parser, like `data:text/javascript,AAA...AAA`. I've personally encountered this when crawling the internet, and links like this DoS'ed my crawler.

Before:

    cpu: AMD Ryzen 9 3900XT 12-Core Processor
    BenchmarkIssue6/1024-24                     4756            274629 ns/op
    BenchmarkIssue6/2048-24                     1408            810745 ns/op
    BenchmarkIssue6/4096-24                      436           2867929 ns/op
    BenchmarkIssue6/8192-24                      124           9629206 ns/op
    BenchmarkIssue6/16384-24                      37          31818247 ns/op
    BenchmarkIssue6/32768-24                      10         111421418 ns/op
    BenchmarkIssue6/65536-24                       3         419345170 ns/op
    BenchmarkIssue6/131072-24                      1        1615991866 ns/op
    BenchmarkIssue6/262144-24                      1        6171892566 ns/op
    BenchmarkIssue6/524288-24                      1        20274211213 ns/op
    BenchmarkIssue6/1048576-24                     1        72145483713 ns/op

After:

    cpu: AMD Ryzen 9 3900XT 12-Core Processor
    BenchmarkIssue6/1024-24                    14553             88384 ns/op
    BenchmarkIssue6/2048-24                     8154            173181 ns/op
    BenchmarkIssue6/4096-24                     3382            344445 ns/op
    BenchmarkIssue6/8192-24                     1722            676524 ns/op
    BenchmarkIssue6/16384-24                     862           1331257 ns/op
    BenchmarkIssue6/32768-24                     447           2682900 ns/op
    BenchmarkIssue6/65536-24                     214           5467865 ns/op
    BenchmarkIssue6/131072-24                    100          10984537 ns/op
    BenchmarkIssue6/262144-24                     51          21710956 ns/op
    BenchmarkIssue6/524288-24                     26          43778980 ns/op
    BenchmarkIssue6/1048576-24                    13          88253304 ns/op

Closes #6