### PR TITLE
Fix panic caused by eponymous params

### DIFF
--- a/url/searchparams.go
+++ b/url/searchparams.go
@@ -102,14 +102,18 @@ func (s *searchParams) Has(name string) bool {
 
 func (s *searchParams) Set(name, value string) {
 	isSet := false
-	for idx, nvp := range s.params {
+	idx := 0
+	for _, nvp := range s.params {
 		if nvp.Name == name {
 			if isSet {
 				s.params = append(s.params[:idx], s.params[idx+1:]...)
 			} else {
 				nvp.Value = value
 				isSet = true
+				idx++
 			}
+		} else {
+			idx++
 		}
 	}
 	if !isSet {

--- a/url/searchparams_test.go
+++ b/url/searchparams_test.go
@@ -151,6 +151,7 @@ func TestUrlSearchParams_Set(t *testing.T) {
 		{"4", "http://example.com?foo=bar&foo=bar2", "foo", "xyz", "foo=xyz"},
 		{"5", "http://example.com?xyz=aaa&foo=bar2&xyz=aaa&foo=bar", "foo", "xyz", "xyz=aaa&foo=xyz&xyz=aaa"},
 		{"6", "http://example.com?xyz=aaa&foo=bar2&xyz=aaa&foo=bar", "foo2", "xyz", "xyz=aaa&foo=bar2&xyz=aaa&foo=bar&foo2=xyz"},
+		{"7", "http://example.com?foo=bar&foo=fuzz&foo=barfuzz", "foo", "xyz", "foo=xyz"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This panic occurred in `searchParams` method `Set` if `searchParams` contains 3 or more params with the same name.

The problem was due to the iteration index. Since the slice is modified during runtime, there was a panic cause of accessing the index out of range.

Closes nlnwa#10