### PR TITLE
Don't modify Url when used as baseUrl during parsing

### DIFF
--- a/url/parser.go
+++ b/url/parser.go
@@ -109,7 +109,7 @@ const (
 
 // BasicParser implements WHATWG basic URL parser (https://url.spec.whatwg.org/#concept-basic-url-parser)
 // In most cases, when possible, prefer using the higher level Parse method.
-func (p *parser) BasicParser(urlOrRef string, base *Url, url *Url, stateOverride State) (*Url, error) {
+func (p *parser) BasicParser(urlOrRef string, baseUrl *Url, url *Url, stateOverride State) (*Url, error) {
 	stateOverridden := stateOverride > NoState
 	if url == nil {
 		url = &Url{inputUrl: urlOrRef, path: &path{}}
@@ -143,6 +143,11 @@ func (p *parser) BasicParser(urlOrRef string, base *Url, url *Url, stateOverride
 	atFlag := false
 	bracketFlag := false
 	passwordTokenSeenFlag := false
+
+	var base *Url
+	if baseUrl != nil {
+		base = baseUrl.Clone()
+	}
 
 	for {
 		r := input.nextCodePoint()
@@ -223,7 +228,7 @@ func (p *parser) BasicParser(urlOrRef string, base *Url, url *Url, stateOverride
 				}
 			} else if base.path.isOpaque() && r == '#' {
 				url.scheme = base.scheme
-				url.path = base.path // TODO: Ensure copy????
+				url.path = base.path
 				url.query = base.query
 				url.fragment = new(string)
 				state = StateFragment
@@ -267,7 +272,7 @@ func (p *parser) BasicParser(urlOrRef string, base *Url, url *Url, stateOverride
 				url.host = base.host
 				url.port = base.port
 				url.decodedPort = base.decodedPort
-				url.path = base.path // TODO: Ensure copy????
+				url.path = base.path
 				url.query = base.query
 				if r == '?' {
 					url.query = new(string)
@@ -456,7 +461,7 @@ func (p *parser) BasicParser(urlOrRef string, base *Url, url *Url, stateOverride
 				state = StateFileSlash
 			} else if base != nil && base.scheme == "file" {
 				url.host = base.host
-				url.path = base.path // TODO: Ensure copy????
+				url.path = base.path
 				url.query = base.query
 				if r == '?' {
 					url.query = new(string)

--- a/url/parser_test.go
+++ b/url/parser_test.go
@@ -233,3 +233,20 @@ func TestDecodedPort(t *testing.T) {
 		t.Errorf("decodedPort got = '%v', want '%v'", relative.decodedPort, u.decodedPort)
 	}
 }
+
+func TestParseShouldNotModifyBaseUrl(t *testing.T) {
+	rawUrl := "http://example.org/ns/foo?adc=ghi#frag"
+	base, err := Parse(rawUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = base.Parse("bar?abc=def#fragment")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if base.String() != rawUrl {
+		t.Errorf("base URL = %v, want %v", base.String(), rawUrl)
+	}
+}

--- a/url/path.go
+++ b/url/path.go
@@ -48,6 +48,20 @@ func (p *path) stripTrailingSpacesIfOpaque() {
 	}
 }
 
+func (p *path) clone() *path {
+	if p == nil {
+		return nil
+	}
+	newPath := &path{
+		opaque: p.opaque,
+	}
+	if p.p != nil {
+		newPath.p = make([]string, len(p.p))
+		copy(newPath.p, p.p)
+	}
+	return newPath
+}
+
 func (p *path) String() string {
 	if p.opaque {
 		return p.p[0]

--- a/url/searchparams.go
+++ b/url/searchparams.go
@@ -184,3 +184,18 @@ func (s *SearchParams) QueryEscape(st string, output *strings.Builder) {
 		}
 	}
 }
+
+// Clone returns a deep copy of the search parameters.
+func (s *SearchParams) Clone() *SearchParams {
+	sp := &SearchParams{
+		url:    s.url,
+		params: make([]*NameValuePair, len(s.params)),
+	}
+	for i, nvp := range s.params {
+		sp.params[i] = &NameValuePair{
+			Name:  nvp.Name,
+			Value: nvp.Value,
+		}
+	}
+	return sp
+}

--- a/url/url.go
+++ b/url/url.go
@@ -304,3 +304,31 @@ func (u *Url) IsIPv4() bool {
 func (u *Url) IsIPv6() bool {
 	return u.isIPv6
 }
+
+// Clone returns a deep copy of the URL.
+func (u *Url) Clone() *Url {
+	return &Url{
+		inputUrl:     u.inputUrl,
+		scheme:       u.scheme,
+		username:     u.username,
+		password:     u.password,
+		host:         cloneStringPointer(u.host),
+		port:         cloneStringPointer(u.port),
+		decodedPort:  u.decodedPort,
+		path:         u.path.clone(),
+		query:        cloneStringPointer(u.query),
+		fragment:     cloneStringPointer(u.fragment),
+		searchParams: u.SearchParams().Clone(),
+		parser:       u.parser,
+		isIPv4:       u.isIPv4,
+		isIPv6:       u.isIPv6,
+	}
+}
+
+func cloneStringPointer(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	c := strings.Clone(*s)
+	return &c
+}

--- a/url/url.go
+++ b/url/url.go
@@ -240,6 +240,11 @@ func (u *Url) SearchParams() *SearchParams {
 	return u.searchParams
 }
 
+func (u *Url) SetSearchParams(searchParams *SearchParams) {
+	u.searchParams = searchParams
+	u.searchParams.update()
+}
+
 func (u *Url) Query() string {
 	if u.query == nil || len(*u.query) == 0 {
 		return ""


### PR DESCRIPTION
This PR ensures a Url used as a baseUrl during parsing is not modified.

Additional features:
- Clone Url
- Clone SearchParams
- Set SearchParams on a Url

Resolves #32 and closes #35. 