### PR TITLE
fix: return failure for missing port

### DIFF
--- a/errors/codes.go
+++ b/errors/codes.go
@@ -53,6 +53,7 @@ const (
 	InvalidReverseSolidus                ErrorType = "The URL has a special scheme and it uses U+005C (\\) instead of U+002F (/)"
 	InvalidCredentials                   ErrorType = "The input includes credentials"
 	HostMissing                          ErrorType = "The input has a special scheme, but does not contain a host"
+	PortMissing                          ErrorType = "The input has a hostname followed by a ':' but is missing the port number"
 	PortOutOfRange                       ErrorType = "The input's port is outside the range [0-65535]"
 	PortInvalid                          ErrorType = "The input's port is not a number"
 	FileInvalidWindowsDriveLetter        ErrorType = "The input is a relative-URL string that starts with a Windows drive letter and the base URL’s scheme is 'file'"

--- a/url/parser.go
+++ b/url/parser.go
@@ -438,6 +438,10 @@ func (p *parser) BasicParser(urlOrRef string, baseUrl *Url, url *Url, stateOverr
 					url.port = &portString
 					url.cleanDefaultPort()
 					buffer.Reset()
+				} else if stateOverridden {
+					if err := p.handleError(url, errors.PortMissing, true); err != nil {
+						return nil, err
+					}
 				}
 				if stateOverridden {
 					return url, nil


### PR DESCRIPTION
For https://url.spec.whatwg.org/#concept-basic-url-parser return failure if the port is missing per https://url.spec.whatwg.org/#port-state clause 2.2.