### PR TITLE
Improve parsing performance

### DIFF
--- a/canonicalizer/canonicalizer.go
+++ b/canonicalizer/canonicalizer.go
@@ -141,6 +141,7 @@ func repeatedDecode(s string) string {
 
 func percentEncode(s string, tr *url.PercentEncodeSet) string {
 	sb := strings.Builder{}
+	sb.Grow(len(s) * 3) // worst case: every rune is percent-encoded
 	for _, b := range []byte(s) {
 		sb.WriteString(percentEncodeByte(b, tr.Set('%')))
 	}
@@ -161,6 +162,7 @@ func percentEncodeByte(b byte, tr *url.PercentEncodeSet) string {
 
 func decodePercentEncoded(s string) string {
 	sb := strings.Builder{}
+	sb.Grow(len(s)) // worst case: no percent-encoding, so same length
 	bytes := []byte(s)
 	for i := 0; i < len(bytes); i++ {
 		if bytes[i] != '%' {

--- a/url/hostparser.go
+++ b/url/hostparser.go
@@ -522,6 +522,7 @@ func (p *parser) stringToUnicode(src string) (string, error) {
 
 func percentEncodeString(s string, tr *PercentEncodeSet) string {
 	sb := strings.Builder{}
+	sb.Grow(len(s) * 3) // worst case: every rune is percent-encoded
 	for _, b := range []byte(s) {
 		sb.WriteString(percentEncodeByte(b, tr))
 	}

--- a/url/hostparser.go
+++ b/url/hostparser.go
@@ -66,13 +66,20 @@ func (p *parser) parseHost(u *Url, parser *parser, input string, isNotSpecial bo
 		}
 	}
 
-	asciiDomain, err := p.ToASCII(domain, false)
-	if err != nil {
-		if p.opts.laxHostParsing {
-			return domain, nil
-		}
-		if err := p.handleWrappedError(u, errors.DomainToASCII, true, err); err != nil {
-			return "", err
+	var asciiDomain string
+	// fast path for common ASCIIAlpha+single_dot+somgle_dash domain
+	if containsOnly(domain, ASCIIAlpha.Clone().Set('.').Set('-')) && !strings.Contains(domain, "..") && !strings.Contains(domain, "--") {
+		asciiDomain = strings.ToLower(domain)
+	} else {
+		var err error
+		asciiDomain, err = p.ToASCII(domain, false)
+		if err != nil {
+			if p.opts.laxHostParsing {
+				return domain, nil
+			}
+			if err := p.handleWrappedError(u, errors.DomainToASCII, true, err); err != nil {
+				return "", err
+			}
 		}
 	}
 	for _, c := range asciiDomain {

--- a/url/hostparser.go
+++ b/url/hostparser.go
@@ -117,6 +117,16 @@ func (p *parser) endsInANumber(u *Url, input string) bool {
 	if last != "" && containsOnly(last, ASCIIDigit) {
 		return true
 	}
+
+	// fast path for common non-hex input
+	if last != "" {
+		tr := ASCIIHexDigit.Clone().Set('x').Set('X')
+		if !containsOnly(last, tr) {
+			return false
+		}
+	}
+
+	// slow path
 	if _, _, err := p.parseIPv4Number(u, last); err == nil || goerrors.Is(err, strconv.ErrRange) {
 		return true
 	}

--- a/url/hostparser.go
+++ b/url/hostparser.go
@@ -50,7 +50,12 @@ func (p *parser) parseHost(u *Url, parser *parser, input string, isNotSpecial bo
 		return p.parseOpaqueHost(u, input)
 	}
 
-	domain := p.DecodePercentEncoded(input)
+	var domain string
+	if strings.IndexByte(input, '%') < 0 { // fast path for non '%' input
+		domain = input
+	} else {
+		domain = p.DecodePercentEncoded(input)
+	}
 
 	if !utf8.ValidString(domain) {
 		if p.opts.laxHostParsing {

--- a/url/inputstring.go
+++ b/url/inputstring.go
@@ -17,7 +17,6 @@
 package url
 
 import (
-	"strings"
 	"unicode/utf8"
 )
 
@@ -90,7 +89,12 @@ func (i *inputString) remainingStartsWith(s string) bool {
 		return false
 	}
 
-	return strings.HasPrefix(string(i.runes[i.pointer+1:]), s)
+	end := i.pointer + 1 + len(s)
+	if end > i.length {
+		return false
+	}
+
+	return string(i.runes[i.pointer+1:end]) == s
 }
 
 // remainingIsInvalidPercentEncoded returns true if the first three characters in the rune array are not '%' followed by two hex digits.

--- a/url/parser.go
+++ b/url/parser.go
@@ -149,6 +149,8 @@ func (p *parser) BasicParser(urlOrRef string, baseUrl *Url, url *Url, stateOverr
 		base = baseUrl.Clone()
 	}
 
+	tr := ASCIIAlphanumeric.Clone().Set(0x2b).Set(0x2d).Set(0x2e)
+
 	for {
 		r := input.nextCodePoint()
 
@@ -166,7 +168,6 @@ func (p *parser) BasicParser(urlOrRef string, baseUrl *Url, url *Url, stateOverr
 				}
 			}
 		case StateScheme:
-			tr := ASCIIAlphanumeric.Clone().Set(0x2b).Set(0x2d).Set(0x2e)
 			if tr.Test(uint(r)) {
 				buffer.WriteRune(unicode.ToLower(r))
 			} else if r == ':' {

--- a/url/parser.go
+++ b/url/parser.go
@@ -913,7 +913,7 @@ func (u *Url) isSpecialScheme(s string) bool {
 }
 
 func (u *Url) getSpecialScheme(s string) (string, bool) {
-	dp, ok := u.parser.opts.specialSchemes[s]
+	dp, ok := u.parser.opts.specialSchemes(s)
 	return dp, ok
 }
 

--- a/url/parser.go
+++ b/url/parser.go
@@ -915,8 +915,7 @@ func (u *Url) getSpecialScheme(s string) (string, bool) {
 }
 
 func (u *Url) isSpecialSchemeAndBackslash(r rune) bool {
-	ok := u.IsSpecialScheme()
-	return ok && r == '\\'
+	return r == '\\' && u.IsSpecialScheme()
 }
 
 func (u *Url) cleanDefaultPort() {

--- a/url/parser.go
+++ b/url/parser.go
@@ -806,8 +806,10 @@ func isSingleDotPathSegment(s string) bool {
 	if s == "." {
 		return true
 	}
-	s = strings.ToLower(s)
-	return s == "%2e"
+	if len(s) != 3 {
+		return false
+	}
+	return s == "%2e" || s == "%2E"
 }
 
 func isDoubleDotPathSegment(s string) bool {

--- a/url/parser.go
+++ b/url/parser.go
@@ -747,6 +747,7 @@ func (p *parser) percentEncodeRune(r rune, tr *PercentEncodeSet) string {
 
 func (p *parser) PercentEncodeString(s string, tr *PercentEncodeSet) string {
 	buffer := &strings.Builder{}
+	buffer.Grow(len(s) * 3) // worst case: every rune is percent-encoded
 	runes := []rune(s)
 	for i, r := range runes {
 		if r == '%' {
@@ -765,6 +766,7 @@ func (p *parser) PercentEncodeString(s string, tr *PercentEncodeSet) string {
 
 func (p *parser) DecodePercentEncoded(s string) string {
 	sb := strings.Builder{}
+	sb.Grow(len(s)) // worst case: no percent-encoding, so same length
 	bytes := []byte(s)
 	for i := 0; i < len(bytes); i++ {
 		if bytes[i] != '%' {
@@ -880,7 +882,7 @@ func remove(s string, tr *bitset.BitSet) (string, bool) {
 		return s, false
 	}
 	changed := false
-	var r []byte
+	r := make([]byte, 0, len(s))
 	for _, c := range []byte(s) {
 		if tr.Test(uint(c)) {
 			changed = true

--- a/url/parseroptions.go
+++ b/url/parseroptions.go
@@ -18,13 +18,23 @@ package url
 
 import "golang.org/x/text/encoding/charmap"
 
-var defaultSpecialSchemes = map[string]string{
-	"ftp":   "21",
-	"file":  "",
-	"http":  "80",
-	"https": "443",
-	"ws":    "80",
-	"wss":   "443",
+func defaultSpecialSchemes(scheme string) (defaultPort string, ok bool) {
+	switch scheme {
+	case "ftp":
+		return "21", true
+	case "file":
+		return "", true
+	case "http":
+		return "80", true
+	case "https":
+		return "443", true
+	case "ws":
+		return "80", true
+	case "wss":
+		return "443", true
+	default:
+		return "", false
+	}
 }
 
 // parserOptions configure a url parser. parserOptions are set by the ParserOption
@@ -40,7 +50,7 @@ type parserOptions struct {
 	percentEncodeSinglePercentSign      bool
 	allowSettingPathForNonBaseUrl       bool
 	skipWindowsDriveLetterNormalization bool
-	specialSchemes                      map[string]string
+	specialSchemes                      func(scheme string) (defaultPort string, ok bool)
 	skipTrailingSlashNormalization      bool
 	encodingOverride                    *charmap.Charmap
 	pathPercentEncodeSet                *PercentEncodeSet
@@ -196,7 +206,10 @@ func WithSkipWindowsDriveLetterNormalization() ParserOption {
 // This API is EXPERIMENTAL.
 func WithSpecialSchemes(special map[string]string) ParserOption {
 	return newFuncParserOption(func(o *parserOptions) {
-		o.specialSchemes = special
+		o.specialSchemes = func(scheme string) (defaultPort string, ok bool) {
+			defaultPort, ok = special[scheme]
+			return
+		}
 	})
 }
 

--- a/url/path.go
+++ b/url/path.go
@@ -66,10 +66,9 @@ func (p *path) String() string {
 	if p.opaque {
 		return p.p[0]
 	} else {
-		output := ""
-		for _, pp := range p.p {
-			output += "/" + pp
+		if len(p.p) == 0 {
+			return ""
 		}
-		return output
+		return "/" + strings.Join(p.p, "/")
 	}
 }

--- a/url/searchparams.go
+++ b/url/searchparams.go
@@ -191,11 +191,6 @@ func (s *SearchParams) Clone() *SearchParams {
 		url:    s.url,
 		params: make([]*NameValuePair, len(s.params)),
 	}
-	for i, nvp := range s.params {
-		sp.params[i] = &NameValuePair{
-			Name:  nvp.Name,
-			Value: nvp.Value,
-		}
-	}
+	copy(sp.params, s.params)
 	return sp
 }

--- a/url/searchparams.go
+++ b/url/searchparams.go
@@ -159,6 +159,11 @@ func (s *SearchParams) Iterate(f func(pair *NameValuePair)) {
 
 func (s *SearchParams) String() string {
 	output := strings.Builder{}
+	toGrow := 0
+	for _, nvp := range s.params {
+		toGrow += (len(nvp.Name) * 3) + (len(nvp.Value) * 3) + 2 // *3 worst case: every rune is percent-encoded; 2 for '=' and '&';
+	}
+	output.Grow(toGrow)
 	for idx, nvp := range s.params {
 		if idx > 0 {
 			output.WriteRune('&')

--- a/url/url.go
+++ b/url/url.go
@@ -42,36 +42,38 @@ type Url struct {
 // Href implements WHATWG url api (https://url.spec.whatwg.org/#api)
 // If excludeFragment is true, the fragment component will be excluded from the output.
 func (u *Url) Href(excludeFragment bool) string {
-	output := u.scheme + ":"
+	var output strings.Builder
+	output.Grow(len(u.inputUrl))
+	output.WriteString(u.scheme + ":")
 	if u.host != nil {
-		output += "//"
+		output.WriteString("//")
 		if u.username != "" || u.password != "" {
-			output += u.username
+			output.WriteString(u.username)
 			if u.password != "" {
-				output += ":" + u.password
+				output.WriteString(":" + u.password)
 			}
-			output += "@"
+			output.WriteString("@")
 		}
-		output += *u.host
+		output.WriteString(*u.host)
 		if u.port != nil {
-			output += ":" + *u.port
+			output.WriteString(":" + *u.port)
 		}
 	}
 	if u.host == nil && !u.path.isOpaque() && len(u.path.p) > 1 && u.path.p[0] == "" {
-		output += "/."
+		output.WriteString("/.")
 	}
 
-	output += u.path.String()
+	output.WriteString(u.path.String())
 
 	if u.query != nil {
-		output += "?" + *u.query
+		output.WriteString("?" + *u.query)
 	}
 
 	if !excludeFragment && u.fragment != nil {
-		output += "#" + *u.fragment
+		output.WriteString("#" + *u.fragment)
 	}
 
-	return output
+	return output.String()
 }
 
 // Protocol implements WHATWG url api (https://url.spec.whatwg.org/#api)

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -473,7 +473,7 @@ func Test_DecodedPort(t *testing.T) {
 	u.SetPort("")
 
 	// Determine default port for scheme
-	defaultPortString := defaultSpecialSchemes[u.Scheme()]
+	defaultPortString, _ := defaultSpecialSchemes(u.Scheme())
 	defaultPort, _ := strconv.Atoi(defaultPortString)
 
 	// DecodedPort() should return 80 by default


### PR DESCRIPTION
Hi, I'm trying to replace github.com/ada-url/goada (C++ with Go binding) with whatwg-url, and I noticed that whatwg-url is a lot slower than goada in many cases.

I made a bunch of performance optimizations based on flame graphs' insights, and saw 30%~100% performance improvements in various cases.

---
Before:

```
BenchmarkParse/1-12       303860              3725 ns/op            1864 B/op         74 allocs/op
BenchmarkParse/2-12       255351              4731 ns/op            2448 B/op        113 allocs/op
BenchmarkParse/3-12       698196              1665 ns/op             864 B/op         41 allocs/op
BenchmarkParse/4-12       830721              1314 ns/op             744 B/op         31 allocs/op
BenchmarkParse/5-12       585558              1856 ns/op            1176 B/op         59 allocs/op
BenchmarkParse/6-12       688225              1590 ns/op            1080 B/op         50 allocs/op
BenchmarkParse/7-12       395816              2993 ns/op            1704 B/op         71 allocs/op
BenchmarkParse/8-12       422863              2827 ns/op            1480 B/op         62 allocs/op
BenchmarkParse/9-12       327033              3358 ns/op            1816 B/op         76 allocs/op
...
```

After:

```
BenchmarkParse/1-12       496786              2181 ns/op            1512 B/op         53 allocs/op
BenchmarkParse/2-12       355843              2958 ns/op            1912 B/op         86 allocs/op
BenchmarkParse/3-12      1313612               921.3 ns/op           600 B/op         26 allocs/op
BenchmarkParse/4-12      1598416               746.9 ns/op           544 B/op         19 allocs/op
BenchmarkParse/5-12      1178409              1007 ns/op             576 B/op         32 allocs/op
BenchmarkParse/6-12      1390153               873.8 ns/op           520 B/op         25 allocs/op
BenchmarkParse/7-12       564979              1921 ns/op            1384 B/op         53 allocs/op
BenchmarkParse/8-12       643351              1851 ns/op            1400 B/op         54 allocs/op
BenchmarkParse/9-12       634221              1950 ns/op            1400 B/op         54 allocs/op
...
```